### PR TITLE
fix gcc15 error

### DIFF
--- a/json/document.h
+++ b/json/document.h
@@ -322,8 +322,6 @@ struct GenericStringRef {
 
     GenericStringRef(const GenericStringRef& rhs) : s(rhs.s), length(rhs.length) {}
 
-    GenericStringRef& operator=(const GenericStringRef& rhs) { s = rhs.s; length = rhs.length; }
-
     //! implicit conversion to plain CharType pointer
     operator const Ch *() const { return s; }
 
@@ -334,6 +332,8 @@ private:
     //! Disallow construction from non-const array
     template<SizeType N>
     GenericStringRef(CharType (&str)[N]) /* = delete */;
+    //! Copy assignment operator not permitted - immutable type
+    GenericStringRef& operator=(const GenericStringRef& rhs) /* = delete */;
 };
 
 //! Mark a character pointer as constant string


### PR DESCRIPTION

Fail to build with gcc15.

https://github.com/Tencent/rapidjson/pull/719
```
/home/phan/b/vcpkg/buildtrees/cocos2dx/src/d-x-3.17.2-3ae40910f3.clean/external/recast/../json/document.h:325:82: error: cannot assign to non-static data member 'length' with const-qualified type 'const SizeType' (aka 'const unsigned int')
  325 |     GenericStringRef& operator=(const GenericStringRef& rhs) { s = rhs.s; length = rhs.length; }
      |                                                                           ~~~~~~ ^
/home/phan/b/vcpkg/buildtrees/cocos2dx/src/d-x-3.17.2-3ae40910f3.clean/external/recast/../json/document.h:331:20: note: non-static data member 'length' declared const here
  331 |     const SizeType length; //!< length of the string (excluding the trailing NULL terminator)
      |     ~~~~~~~~~~~~~~~^~~~~~
4 warnings and 1 error generated.
ninja: build stopped: subcommand failed.
```
